### PR TITLE
fixed bug where certain searches cause electron to freeze

### DIFF
--- a/app/stylesheets/components/searchindex/index_item.css
+++ b/app/stylesheets/components/searchindex/index_item.css
@@ -35,6 +35,8 @@
   margin-top: 5px;
   color: var(--basic-text);
   font-size: 12px;
+  word-wrap: break-word;
+  width: 100%;
 }
 
 /*SmlIndexItem*/
@@ -55,6 +57,7 @@
 
 .sml-index-item-right {
   height: 100%;
+  width: 172px;
   padding: 0px 10px;
   display: flex;
   flex-direction: column;
@@ -71,4 +74,6 @@
   margin-top: 5px;
   color: var(--basic-text);
   font-size: 12px;
+  word-wrap: break-word;
+  width: 100%;
 }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -92,11 +92,6 @@ export const parseDate = date => {
 export const shortenString = (string, maxLength) => {
   if (string.length > maxLength) {
     let idx = maxLength - 3;
-    string = string.slice(0, idx);
-
-    while(string[idx] !== ' ') {
-      idx -= 1;
-    }
     string = string.slice(0, idx) + '...';
   }
   return string;


### PR DESCRIPTION
Fixed issue #48 

The crash is caused by an infinite loop in the helper method `shortenString`. There is a while loop in there that searches backward for a space character so the end of the string is not half a word. If there is not space, then the loop never ends and causes electron to freeze. 

Fixed a styling issue where if the description have a long word, the text will go outside of the box. 